### PR TITLE
[fix]t.text :introduction -’default’

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,9 @@ module RenFa
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
-    config.web_console.whitelisted_ips = '10.0.2.2'
+    unless Rails.env.production?
+      config.web_console.whitelisted_ips = '10.0.2.2'
+  end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20200813191517_create_post_images.rb
+++ b/db/migrate/20200813191517_create_post_images.rb
@@ -3,7 +3,7 @@ class CreatePostImages < ActiveRecord::Migration[5.2]
     create_table :post_images do |t|
       t.string :animal_name, null: false, default: ""
       t.string :image_id, null: false, default: ""
-      t.text :introduction, null: false
+      t.text :introduction
       t.integer :user_id, null: false, default: ""
 
       t.timestamps

--- a/db/migrate/20200813191517_create_post_images.rb
+++ b/db/migrate/20200813191517_create_post_images.rb
@@ -3,7 +3,7 @@ class CreatePostImages < ActiveRecord::Migration[5.2]
     create_table :post_images do |t|
       t.string :animal_name, null: false, default: ""
       t.string :image_id, null: false, default: ""
-      t.text :introduction, null: false, default: ""
+      t.text :introduction, null: false
       t.integer :user_id, null: false, default: ""
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_191517) do
   create_table "post_images", force: :cascade do |t|
     t.string "animal_name", default: "", null: false
     t.string "image_id", default: "", null: false
-    t.text "introduction", default: "", null: false
+    t.text "introduction", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_191517) do
   create_table "post_images", force: :cascade do |t|
     t.string "animal_name", default: "", null: false
     t.string "image_id", default: "", null: false
-    t.text "introduction", null: false
+    t.text "introduction"
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
MySQL の仕様で、データ型が BLOB または TEXT 型のカラムにはデフォルト値を設定することができないため、カラム設定を修正