### PR TITLE
[Change]  t.string :image_id

### DIFF
--- a/db/migrate/20200813191517_create_post_images.rb
+++ b/db/migrate/20200813191517_create_post_images.rb
@@ -2,9 +2,9 @@ class CreatePostImages < ActiveRecord::Migration[5.2]
   def change
     create_table :post_images do |t|
       t.string :animal_name, null: false, default: ""
-      t.string :image_id, null: false, default: ""
+      t.string :image_id
       t.text :introduction
-      t.integer :user_id, null: false, default: ""
+      t.integer :user_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,9 +14,9 @@ ActiveRecord::Schema.define(version: 2020_08_13_191517) do
 
   create_table "post_images", force: :cascade do |t|
     t.string "animal_name", default: "", null: false
-    t.string "image_id", default: "", null: false
+    t.string "image_id"
     t.text "introduction"
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Mysql2::Error:のため、 t.string :image_id,t.integer :user_idの設定削除